### PR TITLE
Automate Docker image build & push to Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+docs
+*.db
+*.md
+arduino
+piscope
+PineappleScope-linux-amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            bmonkman/pineapplescope:latest
+            bmonkman/pineapplescope:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,34 @@
-#FROM scratch
-# FROM gliderlabs/alpine:3.6
-FROM debian
+# Build stage: compile the CGO sqlite binary natively for linux.
+# (Building inside Docker on a Linux runner avoids the cross-compilation pain
+# that previously required xgo.)
+FROM golang:1.21-bookworm AS builder
 
-ADD PineappleScope-linux-amd64 /app
-ADD resources/ /resources/
+WORKDIR /src
+
+# Cache module downloads across builds.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux go build -o /out/pineapplescope ./cmd/pineapplescope
+
+# Runtime stage: slim image with just the binary, templates/assets, and certs.
+FROM debian:bookworm-slim
 
 ENV TZ=America/Vancouver
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update && apt-get install -y ca-certificates && apt-get clean
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /out/pineapplescope /app/pineapplescope
+COPY resources/ /app/resources/
 
 EXPOSE 1111
 
-ENV DBFILE /var/db/pineapplescope.db
+# DB lives on a volume so it survives container recreation/updates.
+ENV DBFILE=/var/db/pineapplescope.db
 VOLUME /var/db/
 
-#CMD ["sleep","1000"]
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/app/pineapplescope"]

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,9 @@ run:
 build: 
 	go build ./cmd/pineapplescope
 
+# Self-contained multi-stage build: compiles the CGO binary inside Docker,
+# so no local Go/xgo toolchain or cross-compilation is needed.
 container:
-	# Wanted to do this when using the super light scratch container but had to do some other stuff in the container so had to drop it
-	#CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
-	# Wanted to do this, but SQLite won't cross-compile properly from OSX->Linux with CGO_ENABLED
-	#CGO_ENABLED=1 GOOS=linux go build -o main .
-	
-	go install src.techknowlogick.com/xgo@latest
-	xgo --targets=linux/amd64 .
-	
 	docker build -t bmonkman/pineapplescope -f Dockerfile .
 
 push:


### PR DESCRIPTION
## What

Adds CI to build and publish the Docker image automatically, so updating the Synology NAS no longer needs a manual local build/push.

- **Multi-stage `Dockerfile`** — compiles the CGO sqlite binary inside a `golang:1.21` builder, ships a slim `debian` runtime. Removes the `xgo` dependency and makes the build self-contained/reproducible in CI. Runtime behavior unchanged (port 1111, `DBFILE=/var/db/...`, `/var/db` volume, Vancouver TZ).
- **`.github/workflows/docker-publish.yml`** — builds and pushes `bmonkman/pineapplescope:latest` and `:<sha>` on push to `master` and via manual "Run workflow".
- **`.dockerignore`** — keeps `.git`, docs, and DB files out of the build context.
- **`make container`** — simplified to the self-contained `docker build` (no xgo).

## Required secrets

Configured in repo settings: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`.

## Verification

Built the multi-stage image locally and ran the container: it serves the UI and CSS (HTTP 200) and auto-migrates its SQLite DB on the volume.

## Note

Merging this PR to `master` is itself a push to `master`, so it will trigger the first build-and-push automatically.