### PR TITLE
Temperature-reactive header color + asset cache-busting

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
+          build-args: |
+            VERSION=${{ github.sha }}
           tags: |
             bmonkman/pineapplescope:latest
             bmonkman/pineapplescope:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=1 GOOS=linux go build -o /out/pineapplescope ./cmd/pineapplescope
+# VERSION (e.g. the git SHA) is baked in so asset URLs bust caches per build.
+ARG VERSION=dev
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-X main.version=${VERSION}" -o /out/pineapplescope ./cmd/pineapplescope
 
 # Runtime stage: slim image with just the binary, templates/assets, and certs.
 FROM debian:bookworm-slim

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 # Self-contained multi-stage build: compiles the CGO binary inside Docker,
 # so no local Go/xgo toolchain or cross-compilation is needed.
 container:
-	docker build -t bmonkman/pineapplescope -f Dockerfile .
+	docker build --build-arg VERSION=$(shell git rev-parse --short HEAD) -t bmonkman/pineapplescope -f Dockerfile .
 
 push:
 	docker push bmonkman/pineapplescope

--- a/cmd/pineapplescope/main.go
+++ b/cmd/pineapplescope/main.go
@@ -18,7 +18,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const version = "0.1.0"
+// version is overridden at build time via -ldflags "-X main.version=<sha>" so
+// asset URLs (?v=...) bust browser caches on every published build.
+var version = "dev"
 
 // AddDbHandle middleware will add the db connection to the context
 func AddDbHandle(db *gorm.DB) gin.HandlerFunc {

--- a/resources/html/base.html
+++ b/resources/html/base.html
@@ -13,13 +13,13 @@
         <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1"></script>
 
         <link rel="icon" sizes="192x192" href="/images/android-desktop.png">
-        <link rel="stylesheet" href="/css/styles.css">
+        <link rel="stylesheet" href="/css/styles.css?v{{ .version }}">
         <link rel="icon" href="/favicon.ico" type="image/x-icon">
         <title>PineappleScope</title>
     </head>
 
     <body>
-        <header class="app-header">
+        <header class="app-header" data-temp="{{ .currentTemp }}">
             <a href="/" title="Home" aria-label="Home">
                 <svg class="icon" viewBox="0 0 24 24"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
             </a>
@@ -33,6 +33,7 @@
             {{ end }}
             <a class="app-header__link" href="/stats">Stats</a>
         </header>
+        <script>applyHeaderTemp();</script>
 
         <main class="container">
             {{ template "content" . }}

--- a/resources/js/pineappleScope.js
+++ b/resources/js/pineappleScope.js
@@ -1,3 +1,22 @@
+// Tint the header from cold (dark blue) to hot (orange) based on kiln temp.
+// Interpolates in HSL so the hue sweeps the warm way: blue -> purple -> red -> orange.
+function tempToColor(tempC) {
+    var COLD = 20, HOT = 1000;
+    var t = Math.max(0, Math.min(1, (tempC - COLD) / (HOT - COLD)));
+    var h = (210 + t * 176) % 360;   // 210 (blue) -> 386 wraps to 26 (orange)
+    var s = 29 + t * 70;             // 29% -> 99%
+    var l = 24 + t * 36;             // 24% -> 60%
+    return 'hsl(' + h.toFixed(0) + ' ' + s.toFixed(0) + '% ' + l.toFixed(0) + '%)';
+}
+
+function applyHeaderTemp() {
+    var header = document.querySelector('.app-header');
+    if (!header) return;
+    var temp = parseFloat(header.getAttribute('data-temp'));
+    if (isNaN(temp)) return;
+    header.style.background = tempToColor(temp);
+}
+
 var toastHideTimer;
 
 function showToast(message, actionText, actionHandler, timeout) {


### PR DESCRIPTION
## What

Two related changes:

### Temperature-reactive header
The top bar is tinted from **dark blue (cold) → orange (hot)** based on the latest kiln temperature. Color is interpolated continuously in HSL so the hue sweeps **blue → purple → red → orange** across 20–1000°C (clamped at both ends). Applied via a small inline script immediately after the header, so there's no flash of the default color.

### Asset cache-busting (fixes stale UI after deploy)
The version stamp on asset URLs was hardcoded (`0.1.0`) and `styles.css` had no stamp at all, so browsers served **stale CSS/JS after every deploy** (this is why the NAS appeared not to update without a hard refresh).

- `version` is now a build-time `var` injected via `-ldflags "-X main.version=<sha>"`
- `?v={{ .version }}` added to the `styles.css` link
- the git SHA flows through the `Dockerfile` (`ARG VERSION` → ldflags), the publish workflow (`build-args: VERSION=${{ github.sha }}`), and `make container`

Now every published build busts the cache automatically — no hard refresh needed.

## Verification

- Color math validated: 20°C→dark blue, 500°C→purple, 750°C→red, 1000°C+→orange (continuous, clamped)
- Built the image with `--build-arg VERSION=...` and ran the container: asset URLs carry the injected version; app serves correctly
- JS syntax-checked; rendered HTML carries `data-temp` and versioned asset URLs