### PR TITLE
Land live firing dashboard + build wiring fix on master

### DIFF
--- a/cmd/pineapplescope/main.go
+++ b/cmd/pineapplescope/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/bmonkman/PineappleScope/handlers"
-	"github.com/bmonkman/PineappleScope/models"
+	"github.com/bmonkman/pineapplescope/internal/handlers"
+	"github.com/bmonkman/pineapplescope/internal/models"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 
@@ -94,6 +94,7 @@ func main() {
 	r.Static("/css", "./resources/css/")
 	r.Static("/images", "./resources/images/")
 	r.StaticFile("/favicon.ico", "./resources/favicon.ico")
+	r.StaticFile("/manifest.json", "./resources/manifest.json")
 
 	// Index
 	r.GET("/", func(c *gin.Context) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/bmonkman/pineapplescope
 go 1.21
 
 require (
-	github.com/bmonkman/PineappleScope v0.0.0-20181222031842-1f6524d9397f
 	github.com/gin-contrib/multitemplate v0.0.0-20230212012517-45920c92c271
 	github.com/gin-gonic/gin v1.9.1
 	github.com/jinzhu/gorm v1.9.16

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJc
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/bmonkman/PineappleScope v0.0.0-20181222031842-1f6524d9397f h1:F77P0DbjPBKEciCfuM1BjB6Q5TTa2DFVWY/H7IdO11g=
-github.com/bmonkman/PineappleScope v0.0.0-20181222031842-1f6524d9397f/go.mod h1:QtyYwLYaG4qy0wDckHiVh0SKqewZGTx2Ja5H+mKZFjw=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.10.0-rc/go.mod h1:ElCzW+ufi8qKqNW0FY314xriJhyJhuoJ3gFZdAHF7NM=
 github.com/bytedance/sonic v1.10.2 h1:GQebETVBxYB7JGWJtLBi07OVzWwt+8dWA00gEVW2ZFE=

--- a/internal/handlers/firing.go
+++ b/internal/handlers/firing.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bmonkman/PineappleScope/models"
+	"github.com/bmonkman/pineapplescope/internal/models"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 )

--- a/internal/handlers/stats.go
+++ b/internal/handlers/stats.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/bmonkman/PineappleScope/models"
+	"github.com/bmonkman/pineapplescope/internal/models"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 )

--- a/internal/handlers/temperature.go
+++ b/internal/handlers/temperature.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bmonkman/PineappleScope/models"
+	"github.com/bmonkman/pineapplescope/internal/models"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 )

--- a/resources/html/base.html
+++ b/resources/html/base.html
@@ -4,6 +4,8 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="mobile-web-app-capable" content="yes">
+        <meta name="theme-color" content="#fe8b36">
+        <link rel="manifest" href="/manifest.json">
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>

--- a/resources/html/firing.html
+++ b/resources/html/firing.html
@@ -14,6 +14,14 @@
                 <span class="info-row__value">{{ .peakTemperature }}˚C</span>
             </div>
             <div class="info-row">
+                <span class="info-row__label">Rate of rise</span>
+                <span class="info-row__value" id="rate-value">—</span>
+            </div>
+            <div class="info-row" id="eta-row" style="display: none;">
+                <span class="info-row__label">Est. time to cone</span>
+                <span class="info-row__value" id="eta-value">—</span>
+            </div>
+            <div class="info-row">
                 <span class="info-row__label">Cone</span>
                 <span class="info-row__value">{{ .firing.ConeNumber }}</span>
             </div>
@@ -54,51 +62,136 @@
 
     <script>
         var myChart;
-        var innerOnlyData = {
-                labels: [ {{ range .temperatureReadings }}moment("{{ .CreatedDate.Format "2006-01-02 15:04:05" }}"),{{ end }} ],
-                datasets: [{
-                    fill: false,
-                    label: 'Temperature',
-                    data: [{{ range .temperatureReadings }}{{ .Inner }},{{ end }}],
-                    borderColor: '#fe8b36',
-                    backgroundColor: '#fe8b36',
-                    lineTension: 0.1,
-                    yAxisID: 'inner'
-                }]
-            };
+        var firingId = {{ .firing.ID }};
+        var coneNumber = "{{ .firing.ConeNumber }}";
+        var showOuter = false;
+        var readings = [
+            {{ range .temperatureReadings }}{ t: "{{ .CreatedDate.Format "2006-01-02 15:04:05" }}", inner: {{ .Inner }}, outer: {{ .Outer }} },{{ end }}
+        ];
 
-            var allData = {
-                labels: [ {{ range .temperatureReadings }}moment("{{ .CreatedDate.Format "2006-01-02 15:04:05" }}"),{{ end }} ],
-                datasets: [{
-                    fill: false,
-                    label: 'Inner Temperature',
-                    data: [{{ range .temperatureReadings }}{{ .Inner }},{{ end }}],
-                    borderColor: '#fe8b36',
-                    backgroundColor: '#fe8b36',
-                    lineTension: 0.1,
-                    yAxisID: 'inner'
-                },
-                {
-                    fill: false,
-                    label: 'Outer Temperature',
-                    data: [{{ range .temperatureReadings }}{{ .Outer }},{{ end }}],
-                    borderColor: '#4caf50',
-                    backgroundColor: '#4caf50',
-                    lineTension: 0.1,
-                    yAxisID: 'outer'
-                }]
-            };
+        // Orton cone end temperatures (°C) at a medium 108°F/hr heating rate.
+        var CONE_TEMPS = {
+            "022":586,"021":600,"020":626,"019":656,"018":686,"017":705,"016":742,
+            "015":750,"014":757,"013":807,"012":843,"011":857,"010":891,
+            "09":907,"08":922,"07":962,"06":998,"05":1031,"04":1063,"03":1086,
+            "02":1102,"01":1119,"1":1137,"2":1142,"3":1152,"4":1162,"5":1186,
+            "6":1222,"7":1239,"8":1249,"9":1260,"10":1285,"11":1294,"12":1306,
+            "13":1321,"14":1388
+        };
+
+        function coneToTemp(cone) {
+            if (!cone) return null;
+            var key = String(cone).trim().replace(/^[∆Δ]?\s*(cone\s*)?/i, '');
+            return CONE_TEMPS.hasOwnProperty(key) ? CONE_TEMPS[key] : null;
+        }
+
+        function buildChartData(rs, withOuter) {
+            var datasets = [{
+                fill: false, label: 'Inner Temperature',
+                data: rs.map(function (r) { return r.inner; }),
+                borderColor: '#fe8b36', backgroundColor: '#fe8b36',
+                lineTension: 0.1, yAxisID: 'inner'
+            }];
+            if (withOuter) {
+                datasets.push({
+                    fill: false, label: 'Outer Temperature',
+                    data: rs.map(function (r) { return r.outer; }),
+                    borderColor: '#4caf50', backgroundColor: '#4caf50',
+                    lineTension: 0.1, yAxisID: 'outer'
+                });
+            }
+            var target = coneToTemp(coneNumber);
+            if (target !== null && rs.length > 0) {
+                datasets.push({
+                    fill: false, label: 'Cone ' + coneNumber.trim() + ' target (' + target + '°C)',
+                    data: rs.map(function () { return target; }),
+                    borderColor: '#9aa0a6', borderDash: [6, 4],
+                    pointRadius: 0, lineTension: 0, yAxisID: 'inner'
+                });
+            }
+            return { labels: rs.map(function (r) { return moment(r.t); }), datasets: datasets };
+        }
+
+        // Rate of rise (°C/hr) over the trailing 10-minute window.
+        function computeRate(rs) {
+            if (rs.length < 2) return null;
+            var last = rs[rs.length - 1];
+            var lastMs = moment(last.t).valueOf();
+            var windowStartMs = lastMs - 10 * 60 * 1000;
+            var ref = rs[rs.length - 2];
+            for (var i = rs.length - 2; i >= 0; i--) {
+                if (moment(rs[i].t).valueOf() >= windowStartMs) { ref = rs[i]; }
+                else break;
+            }
+            var dtHours = (lastMs - moment(ref.t).valueOf()) / 3600000;
+            if (dtHours <= 0) return null;
+            return (last.inner - ref.inner) / dtHours;
+        }
+
+        function formatDuration(hours) {
+            var totalMin = Math.round(hours * 60);
+            var h = Math.floor(totalMin / 60);
+            var m = totalMin % 60;
+            return h > 0 ? h + 'h ' + m + 'm' : m + 'm';
+        }
+
+        function updateStats() {
+            var rate = computeRate(readings);
+            var rateEl = document.getElementById('rate-value');
+            if (rate === null) {
+                rateEl.textContent = '—';
+            } else {
+                rateEl.textContent = (rate >= 0 ? '+' : '−') + Math.abs(rate).toFixed(0) + ' °C/hr';
+            }
+
+            var target = coneToTemp(coneNumber);
+            var current = readings.length ? readings[readings.length - 1].inner : null;
+            var etaRow = document.getElementById('eta-row');
+            if (target !== null && current !== null && rate !== null && rate > 0 && current < target) {
+                document.getElementById('eta-value').textContent =
+                    '~' + formatDuration((target - current) / rate) + ' to cone ' + coneNumber.trim();
+                etaRow.style.display = '';
+            } else {
+                etaRow.style.display = 'none';
+            }
+        }
 
         function addOuterData() {
-            if (myChart.options.scales.outer.display == false) {
-                myChart.data = allData
-            } else {
-                myChart.data = innerOnlyData
-            }
-            myChart.options.scales.outer.display = !myChart.options.scales.outer.display;
+            showOuter = !showOuter;
+            myChart.options.scales.outer.display = showOuter;
+            myChart.data = buildChartData(readings, showOuter);
             myChart.update();
         }
 
-        window.onload = renderChart(innerOnlyData);
+        function refresh() {
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function () {
+                if (this.readyState === 4 && this.status === 200) {
+                    var data = JSON.parse(this.responseText);
+                    readings = data.map(function (r) {
+                        return { t: moment(r.CreatedDate).format('YYYY-MM-DD HH:mm:ss'), inner: r.Inner, outer: r.Outer };
+                    });
+                    myChart.data = buildChartData(readings, showOuter);
+                    myChart.update();
+                    updateStats();
+                    if (readings.length) { setHeaderTemp(readings[readings.length - 1].inner); }
+                }
+            };
+            xhttp.open('GET', '/firing/' + firingId + '/readings', true);
+            xhttp.send();
+        }
+
+        // A firing is "active" (worth live-polling) if its newest reading is recent.
+        function isFiringActive() {
+            if (!readings.length) return false;
+            var lastMs = moment(readings[readings.length - 1].t).valueOf();
+            return (Date.now() - lastMs) < 15 * 60 * 1000;
+        }
+
+        window.onload = function () {
+            renderChart(buildChartData(readings, showOuter));
+            updateStats();
+            if (isFiringActive()) { setInterval(refresh, 30000); }
+        };
     </script>
 {{ end }}

--- a/resources/js/pineappleScope.js
+++ b/resources/js/pineappleScope.js
@@ -9,12 +9,25 @@ function tempToColor(tempC) {
     return 'hsl(' + h.toFixed(0) + ' ' + s.toFixed(0) + '% ' + l.toFixed(0) + '%)';
 }
 
+function setHeaderColor(tempC) {
+    var header = document.querySelector('.app-header');
+    if (header) header.style.background = tempToColor(tempC);
+}
+
+// Initial tint from the server-rendered temp on the header (no flash).
 function applyHeaderTemp() {
     var header = document.querySelector('.app-header');
     if (!header) return;
     var temp = parseFloat(header.getAttribute('data-temp'));
     if (isNaN(temp)) return;
-    header.style.background = tempToColor(temp);
+    setHeaderColor(temp);
+}
+
+// Live update during an active firing: retint and refresh the badge number.
+function setHeaderTemp(tempC) {
+    setHeaderColor(tempC);
+    var badge = document.querySelector('.temp-badge');
+    if (badge) badge.textContent = Math.round(tempC) + '˚C';
 }
 
 var toastHideTimer;

--- a/resources/manifest.json
+++ b/resources/manifest.json
@@ -1,0 +1,17 @@
+{
+    "name": "PineappleScope",
+    "short_name": "PineappleScope",
+    "description": "Kiln firing monitor",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#f5f5f4",
+    "theme_color": "#fe8b36",
+    "icons": [
+        {
+            "src": "/images/android-desktop.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any"
+        }
+    ]
+}


### PR DESCRIPTION
Re-targets the work from #16 to **master**. #16 was accidentally based on `header-temp-color` and merged into that branch instead of master (auto-retarget didn't fire), so its changes never reached master. This PR brings them in. The diff vs master is exactly #16's changes.

## Features (firing detail page)
- **Auto-refresh** — polls `/firing/:id/readings` every 30s while active (newest reading <15 min old), rebuilding the chart, recomputing rate/ETA, retinting the header live.
- **Rate of rise + ETA** — °C/hr over a trailing 10-min window, plus est. time to the cone target while climbing.
- **Cone target line** — dashed reference at the cone's Orton temperature (108°F/hr), e.g. cone 6 → 1222°C.
- **PWA manifest** — installable (`manifest.json` + `theme-color`), served via `main.go`.

## Build wiring fix
Repoints `main.go` + `internal/handlers/*` from the stale capital-P 2018 module to `github.com/bmonkman/pineapplescope/internal/{handlers,models}` and drops the self-`require`. The 2018 module files were byte-identical to `internal/`, so it's a zero-behavior structural fix that makes the repo compile its own code.

## Verification
`go build`, `go vet`, Docker build, and a running container all pass; `go list -deps` resolves to the local module; rendered firing JS syntax-checks clean; key routes + `/manifest.json` return 200.