### PR TITLE
Bound stats table growth (prune + index)

### DIFF
--- a/cmd/pineapplescope/main.go
+++ b/cmd/pineapplescope/main.go
@@ -108,6 +108,9 @@ func main() {
 	handlers.NewTemperatureHandlers(r).Register()
 	handlers.NewStatsHandlers(r).Register()
 
+	// Periodically prune old device stats so the table stays bounded.
+	handlers.StartStatsCleanup(dbConnection)
+
 	r.Run(":1111")
 	dbConnection.Close()
 }

--- a/internal/handlers/cleanup.go
+++ b/internal/handlers/cleanup.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jinzhu/gorm"
+
+	"github.com/bmonkman/pineapplescope/internal/models"
+)
+
+// statsRetentionDays is how long full-resolution device stats are kept. Stats
+// are reported every 60s and rarely reviewed, so old rows are deleted to keep
+// the table from growing unbounded.
+const statsRetentionDays = 90
+
+// PruneOldStats deletes stats records older than the retention window. The
+// cutoff is expressed as a SQLite datetime so it matches how created_date is
+// stored (datetime('now','localtime')) rather than a Go time.Time.
+func PruneOldStats(db *gorm.DB) {
+	whereString := fmt.Sprintf("created_date < datetime('now', 'localtime', '-%d days')", statsRetentionDays)
+	result := db.Where(whereString).Delete(&models.Stats{})
+	if result.Error != nil {
+		fmt.Println("stats cleanup failed:", result.Error)
+		return
+	}
+	fmt.Printf("stats cleanup: removed %d rows older than %d days\n", result.RowsAffected, statsRetentionDays)
+}
+
+// StartStatsCleanup prunes old stats immediately, then once every 24 hours.
+// Running on startup means a restart doesn't have to wait a full day.
+func StartStatsCleanup(db *gorm.DB) {
+	PruneOldStats(db)
+	go func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			PruneOldStats(db)
+		}
+	}()
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -43,7 +43,7 @@ type Photo struct {
 
 type Stats struct {
 	ID                 uint
-	CreatedDate        time.Time `gorm:"default:(datetime('now','localtime'))"`
+	CreatedDate        time.Time `gorm:"default:(datetime('now','localtime'));index"`
 	Uptime             uint64
 	FreeMemory         uint64
 	Temperature        float64


### PR DESCRIPTION
Device stats are reported every 60s (~1,440 rows/day, ~525k/year) and rarely reviewed, so the `stats` table grew unbounded. This caps it without going to a time-series DB.

## Changes
- **`StartStatsCleanup`** (`internal/handlers/cleanup.go`) — deletes stats older than **90 days**, run once at startup and every 24h via a ticker goroutine. Cutoff uses a SQLite `datetime('now','localtime','-90 days')` expression to match how `created_date` is stored (avoids Go/SQLite timezone mismatch); logs rows removed.
- **Index on `Stats.CreatedDate`** — so the daily delete, the `/stats` `ORDER BY created_date DESC LIMIT` sort, and the device-checked-in lookup use the index instead of scanning/sorting the whole table. Matters on the low-power NAS. `AutoMigrate` creates it on the existing DB at startup.
- **Temperature readings left untouched** — they're the firing curves you actually view, and grow 10× slower.

## Verification
- Seeded rows at -200d/-120d/-10d/now; startup prune logged "removed 2 rows older than 90 days", leaving only -10d and now.
- `EXPLAIN QUERY PLAN` for the `/stats` query shows `SCAN stats USING INDEX idx_stats_created_date`.
- `go build` + `go vet` pass; index auto-created on a fresh DB.