### PR TITLE
Color the firing chart line by temperature

### DIFF
--- a/resources/html/firing.html
+++ b/resources/html/firing.html
@@ -90,6 +90,8 @@
                 fill: false, label: 'Inner Temperature',
                 data: rs.map(function (r) { return r.inner; }),
                 borderColor: '#fe8b36', backgroundColor: '#fe8b36',
+                // Tint each segment by its temperature, matching the header bar gradient.
+                segment: { borderColor: function (ctx) { return tempToColor(ctx.p1.parsed.y); } },
                 lineTension: 0.1, yAxisID: 'inner'
             }];
             if (withOuter) {


### PR DESCRIPTION
The inner-temperature line now follows the same blue→orange gradient as the header bar, so it sweeps **blue → purple → red → orange** as the kiln heats.

## How
Uses Chart.js v4 scriptable **segment** styling — each line segment is tinted by its temperature via the same `tempToColor()` the header uses:

```js
segment: { borderColor: function (ctx) { return tempToColor(ctx.p1.parsed.y); } }
```

Value-based (a given temperature is the same color everywhere) and locked to the header's mapping. Frontend only — the ambient line and dashed cone-target line are unchanged.

## Verification
Rendered firing-page JS syntax-checks clean; segment colors confirmed across the range (25°C dark blue → 600°C magenta → 1180°C orange), matching the header gradient.