### PR TITLE
Hide chart point markers; keep hover tooltips

### DIFF
--- a/resources/html/firing.html
+++ b/resources/html/firing.html
@@ -92,6 +92,10 @@
                 borderColor: '#fe8b36', backgroundColor: '#fe8b36',
                 // Tint each segment by its temperature, matching the header bar gradient.
                 segment: { borderColor: function (ctx) { return tempToColor(ctx.p1.parsed.y); } },
+                // Hide the dense point markers (they overpower the gradient line when zoomed out);
+                // show one on hover, tinted to match.
+                pointRadius: 0, pointHoverRadius: 4,
+                pointHoverBackgroundColor: function (ctx) { return tempToColor(ctx.parsed.y); },
                 lineTension: 0.1, yAxisID: 'inner'
             }];
             if (withOuter) {
@@ -99,6 +103,7 @@
                     fill: false, label: 'Outer Temperature',
                     data: rs.map(function (r) { return r.outer; }),
                     borderColor: '#4caf50', backgroundColor: '#4caf50',
+                    pointRadius: 0, pointHoverRadius: 4,
                     lineTension: 0.1, yAxisID: 'outer'
                 });
             }

--- a/resources/js/pineappleScope.js
+++ b/resources/js/pineappleScope.js
@@ -90,10 +90,9 @@ function renderChart(data){
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            tooltips: {
-                mode: 'nearest',
-                intersect: false
-            },
+            // Hover anywhere along the x-axis shows the reading(s) at that time,
+            // so tooltips work even though point markers are hidden.
+            interaction: { mode: 'index', intersect: false },
             scales: {
                 x: {
                     type: "time",


### PR DESCRIPTION
Follow-up to #19. The dense orange point markers overpowered the gradient line when zoomed out — all you'd see were the dots.

## Changes
- **`pointRadius: 0`** on the inner and outer temperature lines (the cone-target line already had it), so only the gradient line shows. A single tinted marker appears on hover (`pointHoverRadius: 4`).
- **Fix hover/tooltips for hidden points:** the old `tooltips: { ... }` block was Chart.js **v2** syntax, ignored in v4 — so tooltips were using the v4 default `intersect: true` (cursor must be on a point). Replaced with `interaction: { mode: 'index', intersect: false }`, so hovering anywhere along the x-axis shows the reading(s) at that time. With the ambient line on, it shows inner + ambient together.

Net: clean gradient line at any zoom, with values on hover (better than before, since hover now works along the whole line, not just on points).

## Verification
`pineappleScope.js` syntax clean (dead v2 block removed, v4 interaction served); `pointRadius: 0` on all three datasets; rendered firing-page JS valid.